### PR TITLE
Jrbogart/write config

### DIFF
--- a/cfg/future_latest.yaml
+++ b/cfg/future_latest.yaml
@@ -2,7 +2,7 @@
 catalog_name : future_latest
 schema_version : 1.1.0
 area_partition :
-  { type: healpix, ordering : ring, nside : 32}
+  { partition_type: healpix, ordering : ring, nside : 32}
 skycatalog_root : /global/cscratch1/sd/jrbogart/desc/skycatalogs
 #skycatalog_root : /global/cscratch1/sd/jrbogart/desc/no_such_dir
 

--- a/cfg/future_latest.yaml
+++ b/cfg/future_latest.yaml
@@ -3,15 +3,14 @@ catalog_name : future_latest
 schema_version : 1.1.0
 area_partition :
   { type: healpix, ordering : ring, nside : 32}
-#skycatalog_root : /global/cscratch1/sd/jrbogart/desc/skycatalogs
-skycatalog_root : /global/cscratch1/sd/jrbogart/desc/no_such_dir
+skycatalog_root : /global/cscratch1/sd/jrbogart/desc/skycatalogs
+#skycatalog_root : /global/cscratch1/sd/jrbogart/desc/no_such_dir
 
 catalog_dir : latest
 #  A sample sky catalog config for partially-faked catalog of stars & galaxies
 #  used as input to create equivalent instance catalogs
 
 SED_models :
-  -
     tophat :
        units : angstrom
        bin_parameters : [start, width]
@@ -22,7 +21,7 @@ SED_models :
                [7385, 458],[7843, 486],[8329, 517],[8846, 549],[9395, 583],
                [9978, 1489],[11467, 1710],[13177, 1966],[15143, 2259],
                [17402, 2596],]
-    file :
+    file_nm :
        units : nm
 
 MW_extinction_values :
@@ -75,6 +74,6 @@ object_types :
   star :
       file_template : 'pointsource_(?P<healpix>\d+).parquet'
       data_file_type : parquet
-      sed_model : file
+      sed_model : file_nm
       sed_file_root : '$SIMS_SED_LIBRARY_DIR'
       MW_extinction : CCM

--- a/cfg/future_latest.yaml
+++ b/cfg/future_latest.yaml
@@ -34,7 +34,7 @@ MW_extinction_values :
 Cosmology :
   Om0 : 0.2648
   Ob0 : 0.0448
-  H0 : 0.71
+  H0 : 71.0
   sigma8 : 0.8
   n_s : 0.963
 

--- a/cfg/latest.yaml
+++ b/cfg/latest.yaml
@@ -1,7 +1,7 @@
 #  A sample sky catalog config for galaxies only
 catalog_name : latest
 area_partition :
-  { type: healpix, ordering : ring, nside : 32}
+  { partition_type: healpix, ordering : ring, nside : 32}
 root_directory : /global/cscratch1/sd/jrbogart/desc/skycatalogs/latest
 #  A sample sky catalog config for partially-faked catalog of stars & galaxies
 #  used as input to create equivalent instance catalogs

--- a/cfg/object_types.yaml
+++ b/cfg/object_types.yaml
@@ -37,4 +37,6 @@ object_types :
       data_file_type : parquet
       sed_model : file_nm
       sed_file_root_env_var : SIMS_SED_LIBRARY_DIR
-      MW_extinction : CCM
+      MW_extinction : F19
+      internal_extinction : None
+      

--- a/cfg/object_types.yaml
+++ b/cfg/object_types.yaml
@@ -1,0 +1,40 @@
+#  Yaml fragment to be incorporated into configs
+object_types :
+  galaxy :
+      file_template : 'galaxy_(?P<healpix>\d+).parquet'
+      flux_file_template : 'galaxy_flux_(?P<healpix>\d+).parquet'
+      data_file_type : parquet
+      composite :
+        bulge : required
+        disk  : required
+        knots : optional
+      attribute_aliases :
+        size_knots_true : size_disk_true
+        size_minor_knots_true : size_minor_disk_true
+  bulge_basic :
+      subtype : bulge
+      parent : galaxy
+      sed_model : tophat
+      internal_extinction : CCM
+      MW_extinction : F19
+      spatial_model : sersic2D
+  disk_basic :
+      subtype : disk
+      parent : galaxy
+      sed_model : tophat
+      internal_extinction : CCM
+      MW_extinction : F19
+      spatial_model :  sersic2D
+  knots_basic :
+      subtype : knots
+      parent : galaxy
+      sed_model : tophat
+      internal_extinction : CCM
+      MW_extinction : F19
+      spatial_model :  knots
+  star :
+      file_template : 'pointsource_(?P<healpix>\d+).parquet'
+      data_file_type : parquet
+      sed_model : file_nm
+      sed_file_root_env_var : SIMS_SED_LIBRARY_DIR
+      MW_extinction : CCM

--- a/cfg/skycatalogs_schema_1.1.0.yaml
+++ b/cfg/skycatalogs_schema_1.1.0.yaml
@@ -1,0 +1,150 @@
+#  Validate our configs using jsonschema by
+#     loading the config and this schema using yaml.load or yaml.safe_load
+#     e.g.
+#  from jsonschema import validate
+#  import yaml
+#  validate(yaml.load('my_cfg.yaml'), yaml.load('future_schema.yaml'))
+#  Fundamental types are
+#       null, boolean, object(=map), array(=list),
+#       number, string
+# what-keyword-goes-here? : "skyCatalogs config"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+"$id": "https://github.com/LSSTDESC/skyCatalog/schema1.1.0.json"
+type : object
+"$defs" :
+  bin :
+    type : array
+    items :
+      type : integer
+    minItems : 2
+    maxItmes : 2
+
+  galaxy_component :
+    type : object
+    properties :
+      subtype :
+        type : string
+      parent :
+        type : string
+      sed_model :
+        type : string
+      internal_extinction :
+        type : string
+      spatial_model :
+        type : string
+      required : [subtype, parent, sed_model, internal_extinction, spatial_model]
+
+required : [catalog_name, schema_version, area_partition, SED_models, Cosmology, object_types]
+properties :
+  catalog_name :
+    type : string
+  schema_version :
+    type : string
+  area_partition :
+    properties :
+      partition_type :
+        type : string
+      ordering :
+        type : string
+      nside :
+        type : integer
+
+  SED_models :
+    type : object
+    properties :
+      tophat :
+        properties :
+          units :
+            type : string
+          bin_parameters :
+            type : array
+            items :
+              type : string
+            minItems : 2
+            maxItems : 2
+          bins :
+            type : array
+            items :
+              type : array
+              items :
+                type : integer
+                minimum : 0
+              maxItems : 2
+              minItems : 2
+            minItems : 1
+        file_nm :
+          properties :
+            units :
+              type : string
+    MW_extinction_values :
+      type : object
+      properties :
+        r_v :
+          properties :
+            mode :
+              type : string
+            value :
+              type : number
+        a_v :
+          properties :
+            mode :
+              type : string
+
+    Cosmology :
+      type : object
+      properties :
+        Om0 :
+          type : number
+        Ob0 :
+          type : number
+        H0 :
+          type : number
+        sigma8 :
+          type : number
+        n_s :
+          type : number
+
+    object_types :
+      type : object
+      properties :
+        galaxy :
+          type : object
+          properties :
+            file_template :
+              type : string
+            data_file_type :
+              type : string
+            sed_file_root :
+              type : string
+            composite :
+              type : object
+              properties :
+                bulge :
+                  type : string
+                disk :
+                  type : string
+                knots :
+                  type : string
+            attribute_aliases :
+              type : object
+              items :
+                type : string
+          bulge_basic :
+            type : { "$ref" : "#/$defs/galaxy_component" }
+          disk_basic :
+            type : { "$ref" : "#/$defs/galaxy_component" }
+          knots_basic :
+            type : { "$ref" : "#/$defs/galaxy_component" }
+          star :
+            type : object
+            properties :
+              file_template :
+                type : string
+              data_file_type :
+                type : string
+              sed_mode :
+                type : string
+              sed_file_root :
+                type : string
+              MW_extinction :
+                type : string

--- a/python/desc/skycatalogs/catalog_creator.py
+++ b/python/desc/skycatalogs/catalog_creator.py
@@ -25,7 +25,6 @@ Code to create a sky catalog for a particular object type
 
 __all__ = ['CatalogCreator']
 
-_Av_adjustment = 2.742
 _MW_rv_constant = 3.1
 
 # This schema is not the same as the one taken from the data,
@@ -98,12 +97,16 @@ def _make_star_schema():
               pa.field('MW_av', pa.float32(), True)]
     return pa.schema(fields)
 
+_Av_adjustment = 2.742
 def _make_MW_extinction(ra, dec):
     '''
     Given arrays of ra & dec, create a MW Av column corresponding to V-band
     correction.
     See "Plotting Dust Maps" example in
     https://dustmaps.readthedocs.io/en/latest/examples.html
+
+    The coefficient _Av_adjustment comes Table 6 in Schlafly & Finkbeiner (2011)
+    See http://iopscience.iop.org/0004-637X/737/2/103/article#apj398709t6
 
     Parameters
     ----------

--- a/python/desc/skycatalogs/catalog_creator.py
+++ b/python/desc/skycatalogs/catalog_creator.py
@@ -21,12 +21,6 @@ Code to create a sky catalog for a particular object type
 
 __all__ = ['CatalogCreator']
 
-'''
-Dict of MW av column names and multipliers needed to create from ebv, MW_rv
-Multipliers come from
-https://iopscience.iop.org/article/10.1088/0004-637X/737/2/103#apj398709t6
-appendix, table 6
-'''
 _Av_adjustment = 2.742
 _MW_rv_constant = 3.1
 

--- a/python/desc/skycatalogs/catalog_creator.py
+++ b/python/desc/skycatalogs/catalog_creator.py
@@ -58,14 +58,8 @@ def _make_galaxy_schema(sed_subdir=False, knots=True):
         fields.append(pa.field('sed_val_knots',
                                pa.list_(pa.float64()), True))
         ### For sizes API can alias to disk sizes
-        ### What else?  magnorm? Probably can be aliased to disk magnorm
-        ### (or do we need to adjust disk magnorm according to the ratio?
-        ###  Don't think so.  Splitting the SED between the two should
-        ###  take care of it.)
         ###  position angle, shears and convergence are all
         ###  galaxy-wide quantities.
-        ### n_knots?  - should be a new field.  When writing out instcat
-        ### entry it will take the place of "sersic index"
         fields.append(pa.field('n_knots', pa.float32(), True))
         fields.append(pa.field('knots_magnorm', pa.float64(), True))
 
@@ -190,10 +184,6 @@ class CatalogCreator:
             self._output_dir = output_dir
         else:
             self._output_dir = os.path.abspath(os.curdir)
-        # if not sedLookup_dir:
-        #     self._sedLookup_dir = _sedLookup_dir
-        # else:
-        #     self._sedLookup_dir = sedLookup_dir
 
         self._output_type = output_type
         self._verbose = verbose
@@ -250,7 +240,6 @@ class CatalogCreator:
 
         # Filename templates: input (sedLookup) and our output.
         # Hardcode for now.
-        ### sedLookup_template = 'sed_fit_{}.h5'
         output_template = 'galaxy_{}.parquet'
         tophat_bulge_re = r'sed_(?P<start>\d+)_(?P<width>\d+)_bulge'
         tophat_disk_re = r'sed_(?P<start>\d+)_(?P<width>\d+)_disk'
@@ -258,7 +247,6 @@ class CatalogCreator:
         # Number of rows to include in a row group
         stride = 1000000
 
-        #native_cut = "native_filters=f'healpix_pixel=={pixel}'"
         hp_filter = [f'healpix_pixel=={pixel}']
         if self._mag_cut:
             r_mag_name = 'mag_r_lsst'
@@ -329,7 +317,6 @@ class CatalogCreator:
 
             for d_name, k_name in zip(sed_disk_names, sed_knot_names):
                 df[k_name] = mag_mask * np.clip(df['knots_flux_ratio'], None, 1-eps) * df[d_name]
-                #df[d_name] = df[d_name] -  df[k_name]
                 df[d_name] = np.where(np.array(df['mag_i_lsst']) > self._knots_mag_cut, 1,
                                       np.clip(1 - df['knots_flux_ratio'], eps, None)) * df[d_name]
         # Re-form sed columns into two arrays

--- a/python/desc/skycatalogs/catalog_creator.py
+++ b/python/desc/skycatalogs/catalog_creator.py
@@ -28,7 +28,7 @@ _MW_rv_constant = 3.1
 
 # This schema is not the same as the one taken from the data,
 # probably because of the indexing in the schema derived from a pandas df.
-def _make_galaxy_schema(sed_subdir=False, knots=True):
+def _make_galaxy_schema(logname, sed_subdir=False, knots=True):
     fields = [pa.field('galaxy_id', pa.int64()),
               pa.field('ra', pa.float64() , True),
 ##                       metadata={"units" : "radians"}),
@@ -55,8 +55,9 @@ def _make_galaxy_schema(sed_subdir=False, knots=True):
               pa.field('disk_magnorm', pa.float64(), True),
               pa.field('MW_rv', pa.float32(), True),
               pa.field('MW_av', pa.float32(), True)]
+    logger = logging.getLogger(logname)
     if knots:
-        print("knots requested")
+        logger.debug("knots requested")
         fields.append(pa.field('sed_val_knots',
                                pa.list_(pa.float64()), True))
         ### For sizes API can alias to disk sizes
@@ -69,8 +70,10 @@ def _make_galaxy_schema(sed_subdir=False, knots=True):
         fields.append(pa.field('bulge_sed_file_path', pa.string(), True))
         fields.append(pa.field('disk_sed_file_path', pa.string(), True))
 
+    debug_out = ''
     for f in fields:
-        print(f.name)
+        debug_out += f'{f.name}\n'
+    logger.debug(debug_out)
     return pa.schema(fields)
 
 
@@ -231,7 +234,8 @@ class CatalogCreator:
 
         self._mag_norm_f = MagNorm(gal_cat.cosmology)
 
-        arrow_schema = _make_galaxy_schema(self._sed_subdir, self._knots)
+        arrow_schema = _make_galaxy_schema(self._logname, self._sed_subdir,
+                                           self._knots)
 
         for p in self._parts:
             print("Starting on pixel ", p)

--- a/python/desc/skycatalogs/utils/__init__.py
+++ b/python/desc/skycatalogs/utils/__init__.py
@@ -1,3 +1,5 @@
 from .common_utils import *
 from .config_utils import *
+from .translate_utils import *
 from .sed_utils import *
+from .exceptions import *

--- a/python/desc/skycatalogs/utils/common_utils.py
+++ b/python/desc/skycatalogs/utils/common_utils.py
@@ -3,8 +3,9 @@ Utilities for top-level scripts
 """
 from datetime import datetime as dt
 import sys
+import logging
 
-__all__ = ['print_callinfo', 'print_date', 'print_dated_msg', 'TIME_TO_SECOND_FMT']
+__all__ = ['print_callinfo', 'log_callinfo', 'print_date', 'print_dated_msg', 'TIME_TO_SECOND_FMT']
 
 TIME_TO_SECOND_FMT = '%Y-%m-%d %H:%M:%S'
 
@@ -25,6 +26,25 @@ def print_callinfo(prog, args):
             print('{}: {}'.format(e, eval(nm)))
 
     sys.stdout.flush()
+
+def log_callinfo(prog, args, logname):
+    """
+    Write information about how a script using argparse was called to log
+
+    Parameters
+    ----------
+    prog   program name, typically sys.argv[0]
+    args   object returned by ArgumentParser.parse_args()
+    logname string
+    """
+
+    logger = logging.getLogger(logname)
+    log_out = '{}  invoked  with arguments\n'.format(prog)
+    for e in dir(args):
+        if not e.startswith('_'):
+            nm = 'args.' + e
+            log_out += '    {}: {}\n'.format(e, eval(nm))
+    logger.info(log_out)
 
 def print_date(to_second=True, file=None):
     """

--- a/python/desc/skycatalogs/utils/config_utils.py
+++ b/python/desc/skycatalogs/utils/config_utils.py
@@ -6,7 +6,9 @@ from desc.skycatalogs.utils.exceptions import NoSchemaVersionError, ConfigDuplic
 
 from collections import namedtuple
 
-__all__ = ['Config', 'open_config_file', 'Tophat']
+__all__ = ['Config', 'open_config_file', 'Tophat', 'create_config']
+
+_CURRENT_SCHEMA_VERSION='1.1.0'
 
 def open_config_file(config_file):
     '''
@@ -121,7 +123,7 @@ class Config(object):
 
         jsonschema.validate(self._cfg, schema.dict)
 
-    def add_key(self, k, d):
+    def add_key(self, k, v):
         '''
         Parameters
         ----------
@@ -129,7 +131,7 @@ class Config(object):
         v        value for the key
         '''
 
-        if k in self._cfg[k]:
+        if k in self._cfg:
             raise ConfigDuplicateKeyError(k)
         self._cfg[k] = v
 
@@ -138,10 +140,13 @@ class Config(object):
         Export self to yaml document and write to specified directory.
         If filename is None the file will be named after catalog_name
         '''
-        self.validate()
+        ###self.validate()   skip for now
 
         if not filename:
             filename = self._cfg['catalog_name'] + '.yaml'
+
+        with open(os.path.join(dirpath, filename), "w") as f:
+            yaml.dump(self._cfg, f)
 
 
 
@@ -155,6 +160,8 @@ def _find_schema_path(schema_spec):
     here = os.path.dirname(__file__)
     return os.path.join(here, '../../../../cfg', fname)
 
-def create_config(catalog_name, schema_version):
+def create_config(catalog_name, schema_version=None):
+    if not schema_version:
+        schema_version = _CURRENT_SCHEMA_VERSION
     return Config({'catalog_name' : catalog_name,
                    'schema_version' : schema_version})

--- a/python/desc/skycatalogs/utils/config_utils.py
+++ b/python/desc/skycatalogs/utils/config_utils.py
@@ -180,13 +180,12 @@ def assemble_MW_extinction():
     rv = {'mode' : 'constant', 'value' : 3.1}
     return {'r_v' : rv, 'a_v' : av}
 
-def assemble_object_types():
+def assemble_object_types(pkg_root):
     '''
     Include all supported object types even though a particular catalog
     might not use them all
     '''
-    here = os.path.dirname(__file__)
-    t_path = os.path.join(here, '../../../../cfg', 'object_types.yaml')
+    t_path = os.path.join(pkg_root, 'cfg', 'object_types.yaml')
     with open(t_path) as f:
         d = yaml.safe_load(f)
         return d['object_types']
@@ -197,8 +196,8 @@ def assemble_SED_models(bins):
     file_nm_d = {'units' : 'nm'}
     return {'tophat' : tophat_d, 'file_nm' : file_nm_d}
 
-def assemble_provenance(inputs={}):
-    repo = git.Repo()
+def assemble_provenance(pkg_root, inputs={}):
+    repo = git.Repo(pkg_root)
     has_uncommited = repo.is_dirty()
     has_untracked = (len(repo.untracked_files) > 0)
 

--- a/python/desc/skycatalogs/utils/config_utils.py
+++ b/python/desc/skycatalogs/utils/config_utils.py
@@ -102,8 +102,8 @@ class Config(object):
         fpath = None
         if schema is None:
             if 'schema_version' not in self._cfg:
-                raise .NoSchemaVersionError
-            fpath = _find_schema(self._cfg["schema_version"])
+                raise NoSchemaVersionError
+            fpath = _find_schema_path(self._cfg["schema_version"])
             if not fpath:
                 raise NoSchemaVersionError('Schema file not found')
         elif isinstance(schema, string):
@@ -113,7 +113,7 @@ class Config(object):
                 f = open(fpath)
                 sch = yaml.safe_load(f)
             except OSError as e:
-                raise e
+                raise NoSchemaVersionError('Schema file not found or unreadable')
             except yaml.YAMLError as ye:
                 raise ye
         if isinstance(schema, dict):
@@ -128,7 +128,7 @@ class Config(object):
         k        Top-level key belonging to the schema
         v        value for the key
         '''
-        #  Ideally should first verify that k is in our schema
+
         if k in self._cfg[k]:
             raise ConfigDuplicateKeyError(k)
         self._cfg[k] = v
@@ -138,13 +138,20 @@ class Config(object):
         Export self to yaml document and write to specified directory.
         If filename is None the file will be named after catalog_name
         '''
+        self.validate()
 
-def _find_schema_name(schema_string):
+        if not filename:
+            filename = self._cfg['catalog_name'] + '.yaml'
+
+
+
+
+def _find_schema_path(schema_spec):
     '''
-    Given a schema version specification, attempt to find the schema file
-    describing it
+    Given a schema version specification, return the file path
+    where the file describing it belongs
     '''
-    fname = f'skycatalogs_config_{self._cfg["schema_string"]}'
+    fname = f'skycatalogs_config_{self._cfg["schema_spec"]}'
     here = os.path.dirname(__file__)
     return = os.path.join(here, '../../../../cfg', fname)
 

--- a/python/desc/skycatalogs/utils/config_utils.py
+++ b/python/desc/skycatalogs/utils/config_utils.py
@@ -1,5 +1,5 @@
 import yaml
-import jsonschema.validate
+from jsonschema import validate
 import os
 
 from desc.skycatalogs.utils.exceptions import NoSchemaVersionError, ConfigDuplicateKeyError
@@ -153,7 +153,7 @@ def _find_schema_path(schema_spec):
     '''
     fname = f'skycatalogs_config_{self._cfg["schema_spec"]}'
     here = os.path.dirname(__file__)
-    return = os.path.join(here, '../../../../cfg', fname)
+    return os.path.join(here, '../../../../cfg', fname)
 
 def create_config(catalog_name, schema_version):
     return Config({'catalog_name' : catalog_name,

--- a/python/desc/skycatalogs/utils/config_utils.py
+++ b/python/desc/skycatalogs/utils/config_utils.py
@@ -50,7 +50,7 @@ class Config(object):
         Return list of named tuples
         Should maybe be part of Sky Catalogs API
         '''
-        raw_bins = self._cfg['SED_models'][0]['tophat']['bins']
+        raw_bins = self._cfg['SED_models']['tophat']['bins']
 
         return [ Tophat(b[0], b[1]) for b in raw_bins]
 

--- a/python/desc/skycatalogs/utils/config_utils.py
+++ b/python/desc/skycatalogs/utils/config_utils.py
@@ -156,7 +156,7 @@ def _find_schema_path(schema_spec):
     Given a schema version specification, return the file path
     where the file describing it belongs
     '''
-    fname = f'skycatalogs_config_{self._cfg["schema_spec"]}'
+    fname = f'skycatalogs_schema_{self._cfg["schema_spec"]}'
     here = os.path.dirname(__file__)
     return os.path.join(here, '../../../../cfg', fname)
 

--- a/python/desc/skycatalogs/utils/exceptions.py
+++ b/python/desc/skycatalogs/utils/exceptions.py
@@ -1,0 +1,10 @@
+class SkyCatalogsException(Exception):
+    pass
+
+class NoSchemaVersionError(SkyCatalogsException):
+    def __init__(self, msg):
+
+        if not msg:
+            msg = 'Schema version unspecified'
+        self.msg = msg
+        super().__init__(self.msg)

--- a/python/desc/skycatalogs/utils/exceptions.py
+++ b/python/desc/skycatalogs/utils/exceptions.py
@@ -1,3 +1,6 @@
+__all__ = ['SkyCatalogsException', 'NoSchemaVersionError',
+           'ConfigDuplicateKeyError']
+
 class SkyCatalogsException(Exception):
     pass
 
@@ -7,4 +10,9 @@ class NoSchemaVersionError(SkyCatalogsException):
         if not msg:
             msg = 'Schema version unspecified'
         self.msg = msg
+        super().__init__(self.msg)
+
+class ConfigDuplicateKeyError(SkyCatalogsException):
+    def __init__(self, key):
+        self.msg = f'Cannot add duplicate key {key} to config'
         super().__init__(self.msg)

--- a/python/desc/skycatalogs/utils/sed_utils.py
+++ b/python/desc/skycatalogs/utils/sed_utils.py
@@ -190,7 +190,9 @@ class MagNorm:
         one_Jy = 1e-26  # W/Hz/m**2
         Lnu = tophat_sed_value*one_maggy    # convert from maggies to W/Hz
         Fnu = Lnu/4/np.pi/self.dl(redshift_hubble)**2
-        return -2.5*np.log10(Fnu/one_Jy) + 8.90
+        with np.errstate(divide='ignore', invalid='ignore'):
+            mgn = -2.5*np.log10(Fnu/one_Jy) + 8.90
+            return mgn
 
 
 class LookupInfo(object):

--- a/python/desc/skycatalogs/utils/translate_utils.py
+++ b/python/desc/skycatalogs/utils/translate_utils.py
@@ -2,8 +2,9 @@ from collections import namedtuple, OrderedDict
 from enum import Enum
 import numpy as np
 
-__all__ = ['column_finder', 'check_file', 'write_to_instance', 'SourceType', 'STAR_FMT', 'CMP_FMT',
-           'form_star_instance_column', 'form_cmp_instance_columns']
+__all__ = ['column_finder', 'check_file', 'write_to_instance', 'SourceType',
+           'STAR_FMT', 'CMP_FMT',
+           'form_star_instance_columns', 'form_cmp_instance_columns']
 
 
 STAR_FMT = '{:s} {:d} {:.14f} {:.14f} {:.8f} {:s} {:d} {:d} {:d} {:d} {:d} {:d} {:s} {:s} {:s} {:.8f} {:f}'

--- a/scripts/create_sc.py
+++ b/scripts/create_sc.py
@@ -31,8 +31,8 @@ parser.add_argument('--skycatalog_root',
 parser.add_argument('--catalog-dir', help='directory for output files relative to skycatalog_root',
                     default='.')
 parser.add_argument('--sed-subdir', help='subdirectory to prepend to paths of galaxy SEDs as written to the sky catalog', default='galaxyTopHatSED')
-parser.add_argument('--verbose', help='print more output if true',
-                    action='store_true')
+parser.add_argument('--loglevel', help='controls logging output',
+                    default='INFO', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
 parser.add_argument('--galaxy-magnitude-cut', default=29.0, type=float,
                     help='Exclude galaxies with r-magnitude above this value')
 parser.add_argument('--knots-magnitude-cut', default=27.0, type=float,
@@ -54,12 +54,11 @@ parser.add_argument('--catalog-name', default='skyCatalog',
 
 args = parser.parse_args()
 logname = 'skyCatalogs.creator'
-loglevel = 'INFO'                 # fixed for now
 logger = logging.getLogger(logname)
-logger.setLevel(loglevel)
+logger.setLevel(args.loglevel)
 
 ch = logging.StreamHandler()
-ch.setLevel(loglevel)
+ch.setLevel(args.loglevel)
 formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 ch.setFormatter(formatter)
 
@@ -77,7 +76,6 @@ creator = CatalogCreator(parts, area_partition, skycatalog_root=skycatalog_root,
                          catalog_dir=args.catalog_dir,
                          write_config=args.write_config,
                          config_path=args.config_path,
-                         verbose=args.verbose,
                          mag_cut=args.galaxy_magnitude_cut,
                          sed_subdir=args.sed_subdir,
                          knots_mag_cut=args.knots_magnitude_cut,

--- a/scripts/create_sc.py
+++ b/scripts/create_sc.py
@@ -31,7 +31,7 @@ parser.add_argument('--skycatalog_root',
 parser.add_argument('--catalog-dir', help='directory for output files relative to skycatalog_root',
                     default='.')
 parser.add_argument('--sed-subdir', help='subdirectory to prepend to paths of galaxy SEDs as written to the sky catalog', default='galaxyTopHatSED')
-parser.add_argument('--loglevel', help='controls logging output',
+parser.add_argument('--log-level', help='controls logging output',
                     default='INFO', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
 parser.add_argument('--galaxy-magnitude-cut', default=29.0, type=float,
                     help='Exclude galaxies with r-magnitude above this value')
@@ -55,10 +55,10 @@ parser.add_argument('--catalog-name', default='skyCatalog',
 args = parser.parse_args()
 logname = 'skyCatalogs.creator'
 logger = logging.getLogger(logname)
-logger.setLevel(args.loglevel)
+logger.setLevel(args.log_level)
 
 ch = logging.StreamHandler()
-ch.setLevel(args.loglevel)
+ch.setLevel(args.log_level)
 formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 ch.setFormatter(formatter)
 

--- a/scripts/create_sc.py
+++ b/scripts/create_sc.py
@@ -25,9 +25,10 @@ parser.add_argument('--no-galaxies', action='store_true',
                     help='if used galaxy catalogs will NOT be created')
 parser.add_argument('--pixels', type=int, nargs='*', default=[9556],
                     help='healpix pixels for which catalogs will be created')
-out_dir = os.path.join(os.getenv('SCRATCH'), 'desc', 'skycatalogs', 'test')
-parser.add_argument('--output-dir', help='directory for output files',
-                    default=out_dir)
+parser.add_argument('--skycatalog_root',
+                    help='Root directory for sky catalogs, typically site-dependent. If not specified, use value environment variable SKYCATALOG_ROOT')
+parser.add_argument('--catalog-dir', help='directory for output files relative to skycatalog_root',
+                    default='.')
 parser.add_argument('--sed-subdir', help='subdirectory to prepend to paths of galaxy SEDs as written to the sky catalog', default='galaxyTopHatSED')
 parser.add_argument('--verbose', help='print more output if true',
                     action='store_true')
@@ -37,16 +38,28 @@ parser.add_argument('--knots-magnitude-cut', default=27.0, type=float,
                     help='Galaxies with i-magnitude above this cut get no knots')
 parser.add_argument('--no-knots', action='store_true', help='If supplied omit knots component. Default is False')
 
+parser.add_argument('--write-config', action='store_true',
+                    help='''If present output config for the new catalog.
+                    Path is determined by --config-path.''')
+parser.add_argument('--config-path', default=None, help='''
+                    Output path for config file. If no value,
+                    config will be written to same location as data,
+                    with filenmame config.yaml''')
+
 args = parser.parse_args()
 
 print_callinfo('create_sc', args)
 
-output_dir = args.output_dir
-
+skycatalog_root = args.skycatalog_root
+if not skycatalog_root:
+    skycatalog_root = os.getenv('SKYCATALOG_ROOT')
 
 parts = args.pixels
 
-creator = CatalogCreator(parts, area_partition, output_dir=output_dir,
+creator = CatalogCreator(parts, area_partition, skycatalog_root=skycatalog_root,
+                         catalog_dir=args.catalog_dir,
+                         write_config=args.write_config,
+                         config_path=args.config_path,
                          verbose=args.verbose,
                          mag_cut=args.galaxy_magnitude_cut,
                          sed_subdir=args.sed_subdir,

--- a/scripts/create_sc.py
+++ b/scripts/create_sc.py
@@ -10,8 +10,9 @@ for details
 
 import os
 import argparse
+import logging
 from desc.skycatalogs.catalog_creator import CatalogCreator
-from desc.skycatalogs.utils.common_utils import print_date, print_callinfo
+from desc.skycatalogs.utils.common_utils import print_date, log_callinfo
 
 
 area_partition = {'type' : 'healpix', 'ordering' : 'ring', 'nside' : 32}
@@ -47,8 +48,19 @@ parser.add_argument('--config-path', default=None, help='''
                     with filenmame config.yaml''')
 
 args = parser.parse_args()
+logname = 'skyCatalogs.creator'
+loglevel = 'INFO'                 # fixed for now
+logger = logging.getLogger(logname)
+logger.setLevel(loglevel)
 
-print_callinfo('create_sc', args)
+ch = logging.StreamHandler()
+ch.setLevel(loglevel)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+
+logger.addHandler(ch)
+
+log_callinfo('create_sc', args, logname)
 
 skycatalog_root = args.skycatalog_root
 if not skycatalog_root:
@@ -65,14 +77,14 @@ creator = CatalogCreator(parts, area_partition, skycatalog_root=skycatalog_root,
                          sed_subdir=args.sed_subdir,
                          knots_mag_cut=args.knots_magnitude_cut,
                          knots=(not args.no_knots))
-print('Starting with healpix pixel ', parts[0])
+logger.info(f'Starting with healpix pixel {parts[0]}')
 if not args.no_galaxies:
-    print("Creating galaxy catalogs")
+    logger.info("Creating galaxy catalogs")
     creator.create('galaxy')
 
 if not args.no_pointsources:
-    print("Creating point source catalogs")
+    logger.info("Creating point source catalogs")
     creator.create('pointsource')
 
-print('All done')
+logger.info('All done')
 print_date()

--- a/scripts/create_sc.py
+++ b/scripts/create_sc.py
@@ -45,7 +45,12 @@ parser.add_argument('--write-config', action='store_true',
 parser.add_argument('--config-path', default=None, help='''
                     Output path for config file. If no value,
                     config will be written to same location as data,
-                    with filenmame config.yaml''')
+                    with filenmame taken from catalog-name''')
+parser.add_argument('--catalog-name', default='skyCatalog',
+                    help='''If write-config option is used, this value
+                    will appear in the config and will be part of
+                    the filename''')
+
 
 args = parser.parse_args()
 logname = 'skyCatalogs.creator'
@@ -76,7 +81,7 @@ creator = CatalogCreator(parts, area_partition, skycatalog_root=skycatalog_root,
                          mag_cut=args.galaxy_magnitude_cut,
                          sed_subdir=args.sed_subdir,
                          knots_mag_cut=args.knots_magnitude_cut,
-                         knots=(not args.no_knots))
+                         knots=(not args.no_knots), logname=logname)
 logger.info(f'Starting with healpix pixel {parts[0]}')
 if not args.no_galaxies:
     logger.info("Creating galaxy catalogs")
@@ -85,6 +90,9 @@ if not args.no_galaxies:
 if not args.no_pointsources:
     logger.info("Creating point source catalogs")
     creator.create('pointsource')
+
+if args.write_config:
+    creator.write_config(args.config_path, args.catalog_name)
 
 logger.info('All done')
 print_date()


### PR DESCRIPTION
The larger part of new or modified code is in support of writing yaml config files as (optionally) part of sky catalog creation. Such a config file may be used as input when opening a catalog with the API.

Other, lesser changes include
* making use of python logger throughout catalog creation
* composing output directory out of a root (settable via command-line option or environment variable) and optional relative dir, similar to arrangement already used to open an existing catalog
* clean-up: fixing typos, eliminating commented-out code, etc.
 