### PR TITLE
U/jrbogart/trim bandpass

### DIFF
--- a/python/desc/skycatalogs/catalog_creator.py
+++ b/python/desc/skycatalogs/catalog_creator.py
@@ -430,7 +430,7 @@ class CatalogCreator:
         from desc.skycatalogs import open_catalog, SkyCatalog
 
         self._gal_flux_schema = make_galaxy_flux_schema(self._logname)
-        BaseObject.get_bp_dir()
+        ###BaseObject.get_bp_dir()
 
         if not config_file:
             #config_file = self._written_config

--- a/python/desc/skycatalogs/catalog_creator.py
+++ b/python/desc/skycatalogs/catalog_creator.py
@@ -433,7 +433,6 @@ class CatalogCreator:
         from desc.skycatalogs import open_catalog, SkyCatalog
 
         self._gal_flux_schema = make_galaxy_flux_schema(self._logname)
-        ###BaseObject.get_bp_dir()
 
         if not config_file:
             #config_file = self._written_config

--- a/python/desc/skycatalogs/catalog_creator.py
+++ b/python/desc/skycatalogs/catalog_creator.py
@@ -96,7 +96,10 @@ def _do_galaxy_flux_chunk(send_conn, galaxy_collection, l_bnd, u_bnd):
         v = all_fluxes_transpose.__next__()
         out_dict[f'lsst_flux_{band}'] = v
 
-    send_conn.send(out_dict)
+    if send_conn:
+        send_conn.send(out_dict)
+    else:
+        return out_dict
 
 class CatalogCreator:
     def __init__(self, parts, area_partition, skycatalog_root=None,
@@ -518,31 +521,37 @@ class CatalogCreator:
             l = l_bnd
             u = min(l_bnd + n_per, u_bnd)
             readers = []
-            # Expect to be able to do about 1500/minute/process
-            tm = int((n_per*60)/500)  # Give ourselves a cushion
-            self._logger.info(f'Using timeout value {tm} for {n_per} sources')
-            for i in range(n_parallel):
-                conn_rd, conn_wrt = Pipe(duplex=False)
-                readers.append(conn_rd)
 
-                # For debugging call directly
-                proc = Process(target=_do_galaxy_flux_chunk,
-                               name=f'proc_{i}',
-                               args=(conn_wrt, _galaxy_collection,l, u))
-                proc.start()
-                l = u
-                u = min(l + n_per, u_bnd)
-            self._logger.debug('Processes started')
-            for i in range(n_parallel):
-                ready = readers[i].poll(tm)
-                if not ready:
-                    self._logger.error(f'Process {i} timed out after {tm} sec')
-                    sys.exit(1)
-                dat = readers[i].recv()
-                for k in ['galaxy_id', 'lsst_flux_u', 'lsst_flux_g',
-                          'lsst_flux_r', 'lsst_flux_i', 'lsst_flux_z',
-                          'lsst_flux_y']:
-                    out_dict[k] += dat[k]
+            if n_parallel == 1:
+                out_dict = _do_galaxy_flux_chunk(None, _galaxy_collection,
+                                                 l, u)
+            else:
+                # Expect to be able to do about 1500/minute/process
+                tm = int((n_per*60)/500)  # Give ourselves a cushion
+                self._logger.info(f'Using timeout value {tm} for {n_per} sources')
+                for i in range(n_parallel):
+                    conn_rd, conn_wrt = Pipe(duplex=False)
+                    readers.append(conn_rd)
+
+                    # For debugging call directly
+                    proc = Process(target=_do_galaxy_flux_chunk,
+                                   name=f'proc_{i}',
+                                   args=(conn_wrt, _galaxy_collection,l, u))
+                    proc.start()
+                    l = u
+                    u = min(l + n_per, u_bnd)
+
+                self._logger.debug('Processes started')
+                for i in range(n_parallel):
+                    ready = readers[i].poll(tm)
+                    if not ready:
+                        self._logger.error(f'Process {i} timed out after {tm} sec')
+                        sys.exit(1)
+                    dat = readers[i].recv()
+                    for k in ['galaxy_id', 'lsst_flux_u', 'lsst_flux_g',
+                              'lsst_flux_r', 'lsst_flux_i', 'lsst_flux_z',
+                              'lsst_flux_y']:
+                        out_dict[k] += dat[k]
 
             out_df = pd.DataFrame.from_dict(out_dict)
             out_table = pa.Table.from_pandas(out_df,
@@ -656,8 +665,6 @@ class CatalogCreator:
         self._ps_flux_schema = make_star_flux_schema(self._logname)
         if not config_file:
             config_file = self.write_config(path_only=True)
-
-        BaseObject.get_bp_dir()
 
         # Always open catalog. If it was opened for galaxies earlier
         # it won't know about star files.

--- a/python/desc/skycatalogs/objects/base_object.py
+++ b/python/desc/skycatalogs/objects/base_object.py
@@ -470,7 +470,7 @@ class BaseObject(object):
 
         # val = self.get_flux(bp, sed=sed)
 
-        val = self.get_flux(lsst_bandpasses[band])
+        val = self.get_flux(lsst_bandpasses[band], sed=sed)
 
         if cache:
             setattr(self, att, val)

--- a/python/desc/skycatalogs/objects/base_object.py
+++ b/python/desc/skycatalogs/objects/base_object.py
@@ -77,9 +77,6 @@ class BaseObject(object):
     Likely need a variant for SSO.
     '''
 
-    ## _bp_path_init = False
-    ## _bp_path = 0
-
     _bp500 = galsim.Bandpass(galsim.LookupTable([499, 500, 501],[0, 1, 0]),
                              wave_type='nm').withZeropoint('AB')
     def __init__(self, ra, dec, id, object_type, redshift=None,
@@ -411,43 +408,10 @@ class BaseObject(object):
         sed = self.get_total_observer_sed()
         return [sed.calculateFlux(b) for b in bandpasses]
 
-    # def get_bp_dir():
-    #     '''
-    #     If throughputs can be found, return that directory. Else
-    #     return None and caller should use GalSim defaults
-    #     '''
-    #     if BaseObject._bp_path_init:
-    #         if BaseObject._bp_path:
-    #             return BaseObject._bp_path
-    #         else:
-    #             return None
-
-    #     BaseObject._bp_path_init = True
-    #     logger = logging.getLogger('skyCatalogs.creator')
-
-    #     rubin_sim_dir = os.getenv('RUBIN_SIM_DATA_DIR', None)
-
-    #     if rubin_sim_dir:
-    #         bp_path = os.path.join(rubin_sim_dir, 'throughputs', 'baseline')
-    #         if os.path.exists(bp_path):
-    #             BaseObject._bp_path = bp_path
-    #             logger.info(f'Using rubin sim dir {rubin_sim_dir}')
-    #             return bp_path
-    #     else:
-    #         bp_path = os.path.join(os.getenv('HOME'), 'rubin_sim_data',
-    #                                'throughputs', 'baseline')
-    #         logger.info(f'Using rubin sim dir rubin_sim_data under HOME')
-    #         if os.path.exists(bp_path):
-    #             BaseObject._bp_path = bp_path
-    #             return bp_path
-
-    #     logger.warning("No rubin sim data dir found. Using GalSim's LSST bandpasses")
-    #     return None
-
     def get_LSST_flux(self, band, sed=None, cache=True):
         if not band in LSST_BANDS:
             return None
-        att = f'flux_{band}'
+        att = f'lsst_flux_{band}'
         # Check if it's already an attribute
         val = getattr(self, att, None)
         if val is not None:
@@ -455,20 +419,6 @@ class BaseObject(object):
 
         if att in self.native_columns:
             return self.get_native_attribute(att)
-
-        # bp_dir = BaseObject.get_bp_dir()
-        # if bp_dir:
-        #     fname = f'total_{band}.dat'
-        #     bp_path = os.path.join(bp_dir, fname)
-        # else:
-        #     # galsim keeps standard bandpass files under
-        #     # os.path.join(galsim.meta_data.share_dir, 'bandpass').
-        #     # These include LSST_u.dat, etc.
-        #     bp_path = f'LSST_{band}.dat'
-
-        # bp = galsim.Bandpass(bp_path, 'nm')
-
-        # val = self.get_flux(bp, sed=sed)
 
         val = self.get_flux(lsst_bandpasses[band], sed=sed)
 

--- a/python/desc/skycatalogs/skyCatalogs.py
+++ b/python/desc/skycatalogs/skyCatalogs.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.ma as ma
 import pyarrow.parquet as pq
 from astropy import units
+from desc.skycatalogs.objects.base_object import load_lsst_bandpasses
 from desc.skycatalogs.objects import *
 from desc.skycatalogs.readers import *
 from desc.skycatalogs.readers import ParquetReader
@@ -485,6 +486,8 @@ def open_catalog(config_file, mp=False, skycatalog_root=None):
     -------
     SkyCatalog
     '''
+    # Get LSST bandpasses in case we need to compute fluxes
+    load_lsst_bandpasses()
     with open(config_file) as f:
         return SkyCatalog(yaml.safe_load(f), skycatalog_root=skycatalog_root,
                           mp=mp)

--- a/python/desc/skycatalogs/skyCatalogs.py
+++ b/python/desc/skycatalogs/skyCatalogs.py
@@ -325,6 +325,8 @@ class SkyCatalog(object):
     def get_object_iterator_by_region(self, region=None, obj_type_set=None,
                                       max_chunk=None, datetime=None):
         '''
+        Not yet implemented.
+
         Parameters
         ----------
         region         Either a box or a circle (each represented as
@@ -361,6 +363,7 @@ class SkyCatalog(object):
         object_list = ObjectList()
 
         if hp not in self._hp_info:
+            print(f'WARNING: In SkyCatalog.get_objects_by_hp healpixel {hp} intersects region but has no catalog file')
             return object_list
 
         G_COLUMNS = ['galaxy_id', 'ra', 'dec']
@@ -472,7 +475,7 @@ class SkyCatalog(object):
         pass
 
 
-def open_catalog(config_file, mp=False, skycatalog_root=None):
+def open_catalog(config_file, mp=False, skycatalog_root=None, verbose=False):
     '''
     Parameters
     ----------
@@ -493,7 +496,7 @@ def open_catalog(config_file, mp=False, skycatalog_root=None):
     load_lsst_bandpasses()
     with open(config_file) as f:
         return SkyCatalog(yaml.safe_load(f), skycatalog_root=skycatalog_root,
-                          mp=mp)
+                          mp=mp, verbose=verbose)
 
 if __name__ == '__main__':
     ###cfg_file_name = 'latest.yaml'

--- a/python/desc/skycatalogs/skyCatalogs.py
+++ b/python/desc/skycatalogs/skyCatalogs.py
@@ -360,6 +360,9 @@ class SkyCatalog(object):
         '''
         object_list = ObjectList()
 
+        if hp not in self._hp_info:
+            return object_list
+
         G_COLUMNS = ['galaxy_id', 'ra', 'dec']
         PS_COLUMNS = ['object_type', 'id', 'ra', 'dec']
         if self.verbose:


### PR DESCRIPTION
Includes
* new code to thin and cache lsst bandpasses
* when creating flux catalogs, if --flux-parallel option value is 1, do processing inline rather than forking subprocesses 
*  bug fix to make use of flux files efficient as intended
* bug fix to keep going if in `get_objects_by_region` not all healpixel files intersecting the region are present