### PR TITLE
do not set __version__ if metadata not available (pkg not installed)

### DIFF
--- a/python/desc/skycatalogs/__init__.py
+++ b/python/desc/skycatalogs/__init__.py
@@ -6,6 +6,10 @@ except ImportError:
     # For Python < 3.8
     import importlib_metadata as metadata
 
-__version__ = metadata.version("skyCatalogs")
+try:
+    __version__ = metadata.version("skyCatalogs")
+except metadata.PackageNotFoundError:
+    pass
+
 from .skyCatalogs import *
 from .catalog_creator import *


### PR DESCRIPTION
Temporary fix, leaving __version__ undefined if the package hasn't been installed.