### PR TITLE
bug-fix in BaseObject.get_LSST_flux

### DIFF
--- a/python/desc/skycatalogs/objects/base_object.py
+++ b/python/desc/skycatalogs/objects/base_object.py
@@ -438,8 +438,8 @@ class BaseObject(object):
     def get_LSST_flux(self, band, sed=None, cache=True, mjd=None):
         if not band in LSST_BANDS:
             return None
+        att = f'lsst_flux_{band}'
         if mjd is None:
-            att = f'lsst_flux_{band}'
             # Check if it's already an attribute
             val = getattr(self, att, None)
             if val is not None:


### PR DESCRIPTION
The `att` needs to be set even if `mjd is not None`, since it's tested below in
```
        if self.object_type != 'sn':
            if att in self.native_columns:
                return self.get_native_attribute(att)
```
and there is no guarantee clients won't provide `mjd` for other `object_type`s.