### PR TITLE
Internally keep ids as strings everywhere

### DIFF
--- a/skycatalogs/skyCatalogs.py
+++ b/skycatalogs/skyCatalogs.py
@@ -76,6 +76,8 @@ def _compress_via_mask(tbl, id_column, region, galaxy=True):
     If there are no objects in the region, all return values are None
 
     '''
+    if isinstance(tbl[id_column][0], (int, np.int64)):
+        tbl[id_column] = [str(an_id) for an_id in tbl[id_column]]
     if region is not None:
         if isinstance(region, PolygonalRegion):        # special case
             # Find bounding box


### PR DESCRIPTION
ObjectCollection used to keep an array of ids in the native format (integers for galaxies but strings for some other source types).  Now that BaseObject always keeps id as a string, ensure input to ObjectCollection creation is always an array of strings.