### PR TITLE
Adjust wavelength arrays for SEDs and MW extinction curves

### DIFF
--- a/skycatalogs/objects/galaxy_object.py
+++ b/skycatalogs/objects/galaxy_object.py
@@ -116,9 +116,8 @@ class GalaxyObject(BaseObject):
             obj_dict[component] = obj._lens(g1, g2, mu)
         return obj_dict
 
-    def get_observer_sed_component(self, component, mjd=None):
-        # For now make SED with resolution of 1 nm
-        sed, _ = self._get_sed(component=component, resolution=1.0)
+    def get_observer_sed_component(self, component, mjd=None, resolution=None):
+        sed, _ = self._get_sed(component=component, resolution=resolution)
         if sed is not None:
             sed = self._apply_component_extinction(sed)
 

--- a/skycatalogs/utils/sed_tools.py
+++ b/skycatalogs/utils/sed_tools.py
@@ -140,13 +140,11 @@ class MilkyWayExtinction:
     '''
     Applies extinction to a SED
     '''
-    def __init__(self, delta_wl=0.1, mwRv=3.1, eps=1e-7):
+    def __init__(self, delta_wl=1.0, mwRv=3.1, eps=1e-7):
         """
         Parameters
         ----------
-        sed_factory: (remove)
-        ext_bin_width: (rename to delta_wl?)
-        delta_wl : float [0.1]
+        delta_wl : float [1.0]
             Wavelength sampling of the extinction function in nm
         mwRv : float [3.1]
             Parameter describing the shape of the Milky Way extinction
@@ -168,7 +166,7 @@ class MilkyWayExtinction:
     def extinguish(self, sed, mwAv):
         ext = self.extinction.extinguish(self.wls*u.nm, Av=mwAv)
         lut = galsim.LookupTable(self.wls, ext, interpolant='linear')
-        mw_ext = galsim.SED(lut, wave_type='nm', flux_type='1')
+        mw_ext = galsim.SED(lut, wave_type='nm', flux_type='1').thin()
         sed = sed*mw_ext
         return sed
 


### PR DESCRIPTION
Overly fine resolution of the wavelength arrays for the SEDs and extinction curves causes downstream inefficiencies when those functions are integrated or merged for composite objects.  To address these issues, we make the following changes:
* We don't need the cosmoDC2 tophat SEDs resampled at 1nm, so eliminate the nominal hard-wired value and just use the tophat representation directly.
* The extinction curves don't need 0.1nm sampling, so increase the initial resolution to 1 nm and call `.thin()` obtain the needed resolution.