### PR TITLE
Add --file option for create_sc

### DIFF
--- a/doc/example-create_sc-options_file.yaml
+++ b/doc/example-create_sc-options_file.yaml
@@ -1,0 +1,5 @@
+pixels : [9683]
+main_only : True
+galaxy_magnitude_cut : 20.0
+no_pointsources : True
+catalog_dir : input_config

--- a/skycatalogs/scripts/create_sc.py
+++ b/skycatalogs/scripts/create_sc.py
@@ -59,22 +59,20 @@ parser.add_argument('--provenance', '--prov', choices=['yaml'], help='''
                      written. Only supported format currently is as a
                      small yaml file, written to the data directory.''')
 parser.add_argument('--dc2', action='store_true', help='If supplied provide values comparable to those used for DC2 run. Default is False')
-parser.add_argument('--file', default='', help='''
+parser.add_argument('--options-file', default=None, help='''
                     path to yaml file associating option names with values. Values for any options
                     included will take precedence.''')
 
 args = parser.parse_args()
 
-if len(args.file) > 0:
-    with open(args.file) as f:
+if args.options_file:
+    with open(args.options_file) as f:
         opt_dict = yaml.safe_load(f)
         for k in opt_dict:
-            try:
-                val = args.__getattribute__(k)
-            except AttributeError as e:
-                raise ValueError(f'Unknown attribute {k} in options file {args.file}')
-            args.__setattr__(k, opt_dict[k])
-
+            if k in args:
+                args.__setattr__(k, opt_dict[k])
+            else:
+                raise ValueError(f'Unknown attribute "{k}" in options file {args.options_file}')
 logname = 'skyCatalogs.creator'
 logger = logging.getLogger(logname)
 logger.setLevel(args.log_level)

--- a/skycatalogs/scripts/create_sc.py
+++ b/skycatalogs/scripts/create_sc.py
@@ -69,6 +69,10 @@ if len(args.file) > 0:
     with open(args.file) as f:
         opt_dict = yaml.safe_load(f)
         for k in opt_dict:
+            try:
+                val = args.__getattribute__(k)
+            except AttributeError as e:
+                raise ValueException(f'Unknown attribute {k} in options file {args.file}')
             args.__setattr__(k, opt_dict[k])
 
 logname = 'skyCatalogs.creator'

--- a/skycatalogs/scripts/create_sc.py
+++ b/skycatalogs/scripts/create_sc.py
@@ -72,7 +72,7 @@ if len(args.file) > 0:
             try:
                 val = args.__getattribute__(k)
             except AttributeError as e:
-                raise ValueException(f'Unknown attribute {k} in options file {args.file}')
+                raise ValueError(f'Unknown attribute {k} in options file {args.file}')
             args.__setattr__(k, opt_dict[k])
 
 logname = 'skyCatalogs.creator'

--- a/skycatalogs/scripts/create_sc.py
+++ b/skycatalogs/scripts/create_sc.py
@@ -10,6 +10,7 @@ for details
 import os
 import argparse
 import logging
+import yaml
 from skycatalogs.catalog_creator import CatalogCreator
 from skycatalogs.utils.common_utils import print_date, log_callinfo
 
@@ -57,10 +58,19 @@ parser.add_argument('--provenance', '--prov', choices=['yaml'], help='''
                      Persist git provenance information for each file
                      written. Only supported format currently is as a
                      small yaml file, written to the data directory.''')
-
 parser.add_argument('--dc2', action='store_true', help='If supplied provide values comparable to those used for DC2 run. Default is False')
+parser.add_argument('--file', default='', help='''
+                    path to yaml file associating option names with values. Values for any options
+                    included will take precedence.''')
 
 args = parser.parse_args()
+
+if len(args.file) > 0:
+    with open(args.file) as f:
+        opt_dict = yaml.safe_load(f)
+        for k in opt_dict:
+            args.__setattr__(k, opt_dict[k])
+
 logname = 'skyCatalogs.creator'
 logger = logging.getLogger(logname)
 logger.setLevel(args.log_level)


### PR DESCRIPTION
Make it possible to supply options to create_sc, the skyCatalogs creation program, via a file.  Any option specified in the file will override defaults and values specified by individual options.