### PR TITLE
use linear interpolant for galaxy SEDs

### DIFF
--- a/skycatalogs/utils/sed_tools.py
+++ b/skycatalogs/utils/sed_tools.py
@@ -114,7 +114,7 @@ class TophatSedFactory:
         flambda *= (1e7/1e4)  # (erg/joule)*(m**2/cm**2)
 
         # Create the lookup table.
-        lut = galsim.LookupTable(self.wl_deltas, flambda, interpolant='nearest')
+        lut = galsim.LookupTable(self.wl_deltas, flambda, interpolant='linear')
 
         if resolution:
             wl_min = min(self.wl_deltas)


### PR DESCRIPTION
  * GalSim treats SEDs more efficiently if they use linear interpolation, so switch to that option.  This should be fine since the vertical transitions between top hat sections have already been replaced by steeply sloped intervals.