### PR TITLE
Sort obj_types to make sure ordering is deterministic

### DIFF
--- a/skycatalogs/skyCatalogs.py
+++ b/skycatalogs/skyCatalogs.py
@@ -379,7 +379,7 @@ class SkyCatalog(object):
             if parent is not None:
                 objs_copy.remove(obj)
                 objs_copy.add(parent)
-        return objs_copy
+        return sorted(objs_copy)  # Sorted to make sure order is deterministic.
 
     def get_objects_by_region(self, region, obj_type_set=None, mjd=None):
         '''


### PR DESCRIPTION
When writing a test in imSim, I ran into a problem that the order of objects coming out of skyCatalog was not stable.  Sometimes stars were first.  Sometimes galaxies.

I tracked it down to the function `toplevel_only`, which uses Python `set` to build the set of unique object types.  All sounds quite reasonable, except that even in Python 3.11, `set` doesn't guarantee the order of iteration to be anything in particular.  Even for exactly equivalent inputs, the result flipped around seemingly at random.  

This surprised me, since I knew they made `dict` ordered starting in Python 3.7.  So I didn't expect set to not be at least stable.  But apparently so.

Anyway, the PR changes that to sort the final `objs_copy`, so that the order is always deterministic.