### PR TITLE
fix call to SnanaObject.get_LSST_flux

### DIFF
--- a/skycatalogs/objects/snana_object.py
+++ b/skycatalogs/objects/snana_object.py
@@ -47,7 +47,7 @@ class SnanaObject(BaseObject):
             # -0.9210340371976184 = -np.log(10)/2.5.
             return np.exp(-0.921034037196184 * mag)
 
-        flux = super().get_LSST_flux(band, sed, mjd)
+        flux = super().get_LSST_flux(band, sed=sed, cache=cache, mjd=mjd)
 
         if flux < 0:
             raise SkyCatalogsRuntimeError('Negative flux')


### PR DESCRIPTION
This fixes the call of `BaseObject.get_LSST_flux(...)` by the `SnanaObject` subclass version.   This fix enables one to set `cache=False` in client code so that different values of `mjd` can be passed for making light curve plots.