### PR TITLE
work around for object types that don't have files for healpixels that have files for other object types

### DIFF
--- a/skycatalogs/skyCatalogs.py
+++ b/skycatalogs/skyCatalogs.py
@@ -540,7 +540,8 @@ class SkyCatalog(object):
         rdr_ot = dict()   # maps readers to set of object types it reads
 
         if 'file_template' in self._config['object_types'][object_type]:
-            f_list = self._hp_info[hp]['object_types'][object_type]
+            f_list = self._hp_info[hp]['object_types'][object_type] \
+                if object_type in self._hp_info[hp]['object_types'] else []
         elif 'parent' in self._config['object_types'][object_type]:
             # ##f_list = self._hp_info[hp]['object_types'][self._config['object_types'][ot]['parent']]
             f_list = self._hp_info[hp]['object_types'][self._config['object_types'][object_type]['parent']]


### PR DESCRIPTION
This is causing a problem when we use the SNANA test files + galaxy + star healpix files where files for some healpixels exist for the latter two, but not for the SNANA data.  I've run into the same problem when I don't have the exact same set of hps for galaxies and point sources.