### PR TITLE
U/jrbogart/config include

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     'astropy',
     'pyarrow',
     'pandas',
-    'sncosmo'
+    'sncosmo',
+    'pyyaml-include'
 ]
 requires-python = ">=3.7" # For setuptools >= 61.0 support
 

--- a/skycatalogs/data/ci_sample/cosmodc2_bulge.yaml
+++ b/skycatalogs/data/ci_sample/cosmodc2_bulge.yaml
@@ -1,0 +1,6 @@
+MW_extinction: F19
+internal_extinction: CCM
+parent: galaxy
+sed_model: tophat
+spatial_model: sersic2D
+subtype: cosmodc2_bulge

--- a/skycatalogs/data/ci_sample/cosmodc2_disk.yaml
+++ b/skycatalogs/data/ci_sample/cosmodc2_disk.yaml
@@ -1,0 +1,6 @@
+MW_extinction: F19
+internal_extinction: CCM
+parent: galaxy
+sed_model: tophat
+spatial_model: sersic2D
+subtype: cosmodc2_disk

--- a/skycatalogs/data/ci_sample/cosmodc2_galaxy.yaml
+++ b/skycatalogs/data/ci_sample/cosmodc2_galaxy.yaml
@@ -1,0 +1,17 @@
+subtype: cosmodc2_galaxy
+attribute_aliases:
+  size_knots_true: size_disk_true
+  size_minor_knots_true: size_minor_disk_true
+composite:
+  bulge: required
+  disk: required
+  knots: optional
+data_file_type: parquet
+file_template: galaxy_(?P<healpix>\d+).parquet
+flux_file_template: galaxy_flux_(?P<healpix>\d+).parquet
+area_partition:
+  type: healpix
+  ordering: ring
+  nside: 32
+galaxy_truth: cosmodc2_v1.1.4_image_addon_knots
+input_api: GCRCatalogs

--- a/skycatalogs/data/ci_sample/cosmodc2_knots.yaml
+++ b/skycatalogs/data/ci_sample/cosmodc2_knots.yaml
@@ -1,0 +1,6 @@
+MW_extinction: F19
+internal_extinction: CCM
+parent: galaxy
+sed_model: tophat
+spatial_model: knots
+subtype: cosmodc2_knots

--- a/skycatalogs/data/ci_sample/dc2_star.yaml
+++ b/skycatalogs/data/ci_sample/dc2_star.yaml
@@ -1,0 +1,13 @@
+subtype : dc2_star
+star_truth: /global/cfs/cdirs/lsst/groups/SSim/DC2/dc2_stellar_healpixel.db
+MW_extinction: F19
+data_file_type: parquet
+file_template: pointsource_(?P<healpix>\d+).parquet
+flux_file_template: pointsource_flux_(?P<healpix>\d+).parquet
+internal_extinction: None
+sed_file_root_env_var: SIMS_SED_LIBRARY_DIR
+sed_model: file_nm
+area_partition:
+  nside: 32
+  ordering: ring
+  type: healpix

--- a/skycatalogs/data/ci_sample/skyCatalog_top.yaml
+++ b/skycatalogs/data/ci_sample/skyCatalog_top.yaml
@@ -1,0 +1,105 @@
+Cosmology:
+  H0: 71.0
+  Ob0: 0.0448
+  Om0: 0.2648
+  n_s: 0.963
+  sigma8: 0.8
+MW_extinction_values:
+  a_v:
+    mode: data
+  r_v:
+    mode: constant
+    value: 3.1
+SED_models:
+  file_nm:
+    units: nm
+  tophat:
+    bin_parameters:
+    - start
+    - width
+    bins:
+    - - 1000
+      - 246
+    - - 1246
+      - 306
+    - - 1552
+      - 381
+    - - 1933
+      - 474
+    - - 2407
+      - 591
+    - - 2998
+      - 186
+    - - 3184
+      - 197
+    - - 3381
+      - 209
+    - - 3590
+      - 222
+    - - 3812
+      - 236
+    - - 4048
+      - 251
+    - - 4299
+      - 266
+    - - 4565
+      - 283
+    - - 4848
+      - 300
+    - - 5148
+      - 319
+    - - 5467
+      - 339
+    - - 5806
+      - 360
+    - - 6166
+      - 382
+    - - 6548
+      - 406
+    - - 6954
+      - 431
+    - - 7385
+      - 458
+    - - 7843
+      - 486
+    - - 8329
+      - 517
+    - - 8846
+      - 549
+    - - 9395
+      - 583
+    - - 9978
+      - 1489
+    - - 11467
+      - 1710
+    - - 13177
+      - 1966
+    - - 15143
+      - 2259
+    - - 17402
+      - 2596
+    units: angstrom
+area_partition:
+  nside: 32
+  ordering: ring
+  type: healpix
+catalog_dir: ci_sample
+catalog_name: skyCatalog
+object_types:
+  bulge: !include cosmodc2_bulge.yaml
+  disk: !include cosmodc2_disk.yaml
+  galaxy: !include cosmodc2_galaxy.yaml
+  knots: !include cosmodc2_knots.yaml
+  star: !include dc2_star.yaml
+provenance:
+  inputs:
+    galaxy_truth: cosmodc2_v1.1.4_image_addon_knots
+    sn_truth: /global/cfs/cdirs/lsst/groups/SSim/DC2/cosmoDC2_v1.1.4/sne_cosmoDC2_v1.1.4_MS_DDF_healpix.db
+    star_truth: /global/cfs/cdirs/lsst/groups/SSim/DC2/dc2_stellar_healpixel.db
+  skyCatalogs_repo:
+    git_branch: master
+    git_hash: defa84b868c1067d354b19a8287ace339d286790
+    git_status:
+    - UNTRACKED_FILES
+schema_version: 1.1.0
+skycatalog_root: /global/cscratch1/sd/jrbogart/desc/skycatalogs

--- a/skycatalogs/readers/parquet_reader.py
+++ b/skycatalogs/readers/parquet_reader.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import os
 import pyarrow.parquet as pq
 import numpy as np
 import numpy.ma as ma
@@ -14,9 +15,10 @@ class ParquetReader:
     '''
     def __init__(self, filepath, mask=None):
         self._filepath = filepath
+        self._abs = abs = os.path.abspath(filepath)
         # meta data includes num_columns, num_rows, num_row_groups
-        self._meta = pq.read_metadata(filepath)
-        self._schema = pq.read_schema(filepath)
+        self._meta = pq.read_metadata(abs)
+        self._schema = pq.read_schema(abs)
         self._columns = set(self._schema.names)
         #  To support iterator also save # row groups, length of each.
         #  If mask, must be able to get slices corresponding to the different
@@ -24,7 +26,7 @@ class ParquetReader:
         self._open()
 
     def _open(self):
-        self._pqfile = pq.ParquetFile(self._filepath)
+        self._pqfile = pq.ParquetFile(self._abs)
 
     def close(self):
         '''

--- a/skycatalogs/skyCatalogs.py
+++ b/skycatalogs/skyCatalogs.py
@@ -2,6 +2,7 @@ import os
 import sys
 import re
 import yaml
+from yamlinclude import YamlIncludeConstructor
 import logging
 import healpy
 import numpy as np
@@ -343,6 +344,62 @@ class SkyCatalog(object):
     def _validate_config(self):
         pass
 
+    def _find_hps_by_type(self, name, type_config):
+        '''
+        Parameters
+        ----------
+        name        string    object type name
+        type_config      dict      config information about name
+
+        Returns
+        -------
+        set of healpixels with data for specified type
+
+        Side-effects: Update self._hp_info
+        '''
+        # Assume flux files, if they exist, are in same dir. as main files
+        if 'file_template' not in type_config:
+            return set()
+        tmpl = type_config['file_template']
+        rel_dir, tmpl = os.path.split(tmpl)
+        tmpl_keys = [tmpl]
+        if 'flux_file_template' in type_config:
+            flux_tmpl = type_config['flux_file_template']
+            flux_dir, flux_tmpl = os.path.split(flux_tmpl)
+            if flux_dir != rel_dir:
+                raise ValueError(f'Flux and main files for {name} in different directories')
+            tmpl_keys.append(flux_tmpl)
+        to_search = self._cat_dir
+        if rel_dir != '':
+            to_search = os.path.join(self._cat_dir, rel_dir)
+
+        files = os.listdir(to_search)
+        hp_set = set()
+        for f in files:
+            if rel_dir == '':
+                fpath = f
+            else:
+                fpath = os.path.join(rel_dir, f)
+            for k in tmpl_keys:
+                m = re.fullmatch(k, f)
+                if m:
+                    hp = int(m['healpix'])
+                    hp_set.add(hp)
+
+                    if hp not in self._hp_info:
+                        self._hp_info[hp] = {'files': {fpath: None},
+                                             'object_types': {name: [fpath]}}
+                    else:
+                        this_hp = self._hp_info[hp]
+                        # Value of 'object_types' is now a list
+                        if fpath not in this_hp['files']:
+                            this_hp['files'][fpath] = None
+                        if name in this_hp['object_types']:
+                            this_hp['object_types'][name].append(fpath)
+                        else:
+                            this_hp['object_types'][name] = [fpath]
+        return hp_set
+
     def _find_all_hps(self):
         '''
         For each healpix with files matching pattern in the directory,
@@ -354,36 +411,17 @@ class SkyCatalog(object):
         Sorted list of healpix pixels with at least one file in the directory
 
         '''
-        # If major organization is by healpix, healpix # could be in
-        # subdirectory name.  Otherwise there may be no subdirectories
-        # or data may be organized by component type.
-        # Here only handle case where data files are directly in root dir
-        files = os.listdir(self._cat_dir)
-        o_types = self._config['object_types']
+        if len(self._hp_info) > 0:
+            hp_list = list(self._hp_info.keys())
+            hp_list.sort()
+            return hp_list
 
+        o_types = list(self.toplevel_only((self._config['object_types'])))
         hp_set = set()
-        for f in files:
-            for ot in o_types:
-                # find all keys containing the string 'file_template'
-                tmplt_keys = [k for k in o_types[ot] if 'file_template' in k]
-                for k in tmplt_keys:
-                    m = re.fullmatch(o_types[ot][k], f)
-                    if m:
-                        hp = int(m['healpix'])
-                        hp_set.add(hp)
+        for (k, v) in [(o_t, self._config['object_types'][o_t]) for o_t in o_types]:
+            new_hps = self._find_hps_by_type(k, v)
+            hp_set.update(new_hps)
 
-                        if hp not in self._hp_info:
-                            self._hp_info[hp] = {'files': {f: None},
-                                                 'object_types': {ot: [f]}}
-                        else:
-                            this_hp = self._hp_info[hp]
-                            # Value of 'object_types' is now a list
-                            if f not in this_hp['files']:
-                                this_hp['files'][f] = None
-                            if ot in this_hp['object_types']:
-                                this_hp['object_types'][ot].append(f)
-                            else:
-                                this_hp['object_types'][ot] = [f]
         hp_list = list(hp_set)
         hp_list.sort()
         return hp_list
@@ -427,7 +465,7 @@ class SkyCatalog(object):
         object_types     Set of object type names
         Remove object types with a parent.  Add in the parent.
 
-        Return the resulting set
+        Return the resulting types (as list) and their values
         '''
         objs_copy = set(object_types)
         for obj in object_types:
@@ -653,6 +691,9 @@ def open_catalog(config_file, mp=False, skycatalog_root=None, verbose=False):
     '''
     # Get LSST bandpasses in case we need to compute fluxes
     _ = load_lsst_bandpasses()
+    base_dir = os.path.dirname(config_file)
+    YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.SafeLoader,
+                                               base_dir=base_dir)
     with open(config_file) as f:
         return SkyCatalog(yaml.safe_load(f), skycatalog_root=skycatalog_root,
                           mp=mp, verbose=verbose)

--- a/skycatalogs/skyCatalogs.py
+++ b/skycatalogs/skyCatalogs.py
@@ -475,13 +475,15 @@ class SkyCatalog(object):
         -------
         All object type names in the catalog's config
         '''
-
         names = list(set(self._config['object_types'].keys()))
         names.sort()
         return names
 
-    # Add more functions to return parts of config of possible interest
-    # to user
+    def default_object_type_set(self):
+        if 'default_object_types' in self._config.keys():
+            return set(self._config['default_object_types'])
+        else:
+            return self.get_object_type_names()
 
     def toplevel_only(self, object_types):
         '''
@@ -506,7 +508,8 @@ class SkyCatalog(object):
         ----------
         region         region is a named tuple(may be box or circle)
                        or object of type PolygonalRegion
-        obj_type_set   Return only these objects. Defaults to all available
+        obj_type_set   Return only these objects. Defaults to value in config if
+                       specified; else default to all defined in config
         mjd            MJD of observation epoch.
 
         Returns
@@ -523,7 +526,7 @@ class SkyCatalog(object):
 
         object_list = ObjectList()
         if obj_type_set is None:
-            obj_types = self.get_object_type_names()
+            obj_types = self.default_object_type_set()
         else:
             obj_types = set(self.get_object_type_names()).intersection(obj_type_set)
         obj_types = self.toplevel_only(obj_types)

--- a/skycatalogs/skyCatalogs.py
+++ b/skycatalogs/skyCatalogs.py
@@ -403,8 +403,9 @@ class SkyCatalog(object):
     def _find_all_hps(self):
         '''
         For each healpix with files matching pattern in or under the
-        containing the config file, update _hp_info as needed to keep
-        track of all files for that healpix and the object types included in those files.
+        directory containing the config file, update _hp_info as needed to keep
+        track of all files for that healpix and the object types included in
+        those files.
 
         Returns
         -------

--- a/tests/test_API.py
+++ b/tests/test_API.py
@@ -25,7 +25,7 @@ class APITester(unittest.TestCase):
         skycatalog_root = os.path.join(Path(__file__).resolve().parents[1],
                                        'skycatalogs', 'data')
         self._skycatalog_root = skycatalog_root
-        cfg_path = os.path.join(skycatalog_root, 'ci_sample', 'skyCatalog.yaml')
+        cfg_path = os.path.join(skycatalog_root, 'ci_sample', 'skyCatalog_top.yaml')
         self._cat = open_catalog(cfg_path, skycatalog_root=skycatalog_root)
 
 


### PR DESCRIPTION
Addresses issue #76
Allow use of include files within a config.  The primary motivation and expected use is to allow the config information for an object type to be in a separate file which can be in a subdirectory of the catalog dir (where the top-level config file is) along with the data for that type.  The subdirectory may be a sym link. 