### PR TITLE
allow gaia data_dir to be absolute path

### DIFF
--- a/skycatalogs/objects/gaia_object.py
+++ b/skycatalogs/objects/gaia_object.py
@@ -1,7 +1,6 @@
 import os
 import warnings
 from functools import wraps
-import itertools
 from collections.abc import Iterable
 from pathlib import PurePath
 import numpy as np
@@ -157,7 +156,10 @@ def _read_fits(htm_id, gaia_config, sky_root, out_dict, logger, region=None):
     f_dir = gaia_config['data_dir']
     f_name = gaia_config['basename_template'].replace('(?P<htm>\\d+)',
                                                       f'{htm_id}')
-    f_path = os.path.join(sky_root, f_dir, f_name)
+    if os.path.isabs(f_dir):
+        f_path = os.path.join(f_dir, f_name)
+    else:
+        f_path = os.path.join(sky_root, f_dir, f_name)
     if not os.path.isfile(f_path):
         logger.info(f'No file for requested htm id {htm_id}')
         return
@@ -236,6 +238,7 @@ class GaiaCollection(ObjectCollection):
     def set_config(cls, config):
         GaiaCollection._gaia_config = config
         GaiaCollection._id_prefix = config['id_prefix']
+
     @classmethod
     def get_config(cls):
         return GaiaCollection._gaia_config

--- a/skycatalogs/utils/config_utils.py
+++ b/skycatalogs/utils/config_utils.py
@@ -71,7 +71,7 @@ class YamlIncludeLoader(yaml.SafeLoader):
             raise yaml.constructor.ConstructorError
 
     def extractFile(self, filepath: str) -> Any:
-        if filepath.startswith('/'):
+        if os.path.isabs(filepath):
             actual_path = filepath
         else:
             actual_path = os.path.join(self._current_dir, filepath)


### PR DESCRIPTION
The update makes it possible to use an absolute path to specify where  data files may be found.
To access files at sdf for Gaia dr2, the skyCatalogs config file should contain a section like this:

```
object_types:
  gaia_star:
    area_partition:
      level: 7
      type: htm
    id_prefix: gaia_dr2_
    data_file_type: fits
    data_dir: /sdf/group/rubin/datasets/refcats/htm/v1/gaia_dr2_20200414
    basename_template: (?P<htm>\d+).fits
    sed_method: use_lut
```
optionally followed by more object type sections.