### PR TITLE
magnorm fix

### DIFF
--- a/skycatalogs/objects/base_object.py
+++ b/skycatalogs/objects/base_object.py
@@ -195,7 +195,7 @@ class BaseObject(object):
 
         Returns
         -------
-        A pair (sed, mag_norm)
+        galsim.SED object
 
         Must be implemented by subclass
         '''
@@ -203,7 +203,7 @@ class BaseObject(object):
 
     def write_sed(self, sed_file_path, component=None, resolution=None,
                   mjd=None):
-        sed, _ = self._get_sed(component=component, resolution=None, mjd=None)
+        sed = self._get_sed(component=component, resolution=None, mjd=None)
 
         wl = sed.wave_list
         flambda = [sed(w) for w in wl]

--- a/skycatalogs/objects/base_object.py
+++ b/skycatalogs/objects/base_object.py
@@ -89,9 +89,6 @@ class BaseObject(object):
     Likely need a variant for SSO.
     '''
 
-    _bp500 = galsim.Bandpass(galsim.LookupTable([499, 500, 501], [0, 1, 0]),
-                             wave_type='nm').withZeropoint('AB')
-
     def __init__(self, ra, dec, id, object_type, belongs_to, belongs_index):
         '''
         Save at least minimum info needed a fixed (not SSO) object to

--- a/skycatalogs/objects/diffsky_object.py
+++ b/skycatalogs/objects/diffsky_object.py
@@ -25,7 +25,7 @@ class DiffskyObject(BaseObject):
 
         Returns
         -------
-        A pair (sed, mag_norm)
+        galsim.SED object
         '''
 
         if component not in ['disk', 'bulge', 'knots']:
@@ -39,8 +39,7 @@ class DiffskyObject(BaseObject):
             sky_cat = self._belongs_to._sky_catalog
             self._seds = sky_cat.observed_sed_factory.create(pixel, self.id, z_h, z)
 
-        magnorm = None
-        return self._seds[component], magnorm
+        return self._seds[component]
 
     def get_knot_size(self,z):
         """
@@ -147,7 +146,7 @@ class DiffskyObject(BaseObject):
         return obj_dict
 
     def get_observer_sed_component(self, component, mjd=None, resolution=None):
-        sed, _ = self._get_sed(component)
+        sed = self._get_sed(component)
         if sed is not None:
             sed = self._apply_component_extinction(sed)
         return sed

--- a/skycatalogs/objects/galaxy_object.py
+++ b/skycatalogs/objects/galaxy_object.py
@@ -12,17 +12,16 @@ class GalaxyObject(BaseObject):
 
     def _get_sed(self, component=None, resolution=None):
         '''
-        Return sed and mag_norm for a galaxy component or for a star
+        Return sed for a galaxy component
         Parameters
         ----------
         component    one of 'bulge', 'disk', 'knots' for now. Other components
-                     may be supported.  Ignored for stars
-        resolution   desired resolution of lambda in nanometers. Ignored
-                     for stars.
+                     may be supported.
+        resolution   desired resolution of lambda in nanometers.
 
         Returns
         -------
-        A pair (sed, mag_norm)
+        galsim.SED object
         '''
         if component not in ['disk', 'bulge', 'knots']:
             raise ValueError(f'Cannot fetch SED for component type {component}')
@@ -33,7 +32,7 @@ class GalaxyObject(BaseObject):
 
         # if values are all zeros or nearly no point in trying to convert
         if max(th_val) < np.finfo('float').resolution:
-            return None, 0.0
+            return None
 
         z_h = self.get_native_attribute('redshift_hubble')
         z = self.get_native_attribute('redshift')
@@ -41,9 +40,7 @@ class GalaxyObject(BaseObject):
         sky_cat = self._belongs_to._sky_catalog
         sed = sky_cat.observed_sed_factory.create(th_val, z_h, z,
                                                   resolution=resolution)
-        magnorm = sky_cat.observed_sed_factory.magnorm(th_val, z_h)
-
-        return sed, magnorm
+        return sed
 
     def get_knot_size(self,z):
         """
@@ -146,7 +143,7 @@ class GalaxyObject(BaseObject):
 
 
     def get_observer_sed_component(self, component, mjd=None, resolution=None):
-        sed, _ = self._get_sed(component=component, resolution=resolution)
+        sed = self._get_sed(component=component, resolution=resolution)
         if sed is not None:
             sed = self._apply_component_extinction(sed)
 

--- a/skycatalogs/objects/snana_object.py
+++ b/skycatalogs/objects/snana_object.py
@@ -32,9 +32,9 @@ class SnanaObject(BaseObject):
         mjd_start = self.get_native_attribute('start_mjd')
         mjd_end = self.get_native_attribute('end_mjd')
         if mjd < mjd_start or mjd > mjd_end:
-            return None, 0.0
+            return None
 
-        return self._linear_interp_SED(mjd), 0.0
+        return self._linear_interp_SED(mjd)
 
     def _apply_flux_correction(self, flux, snana_band, mjd):
         def _flux_ratio(mag):
@@ -95,7 +95,7 @@ class SnanaObject(BaseObject):
             txt = 'SnananObject.get_observer_sed_component: no mjd specified for this call\n'
             txt += 'nor when generating object list'
             raise ValueError(txt)
-        sed, _ = self._get_sed(mjd=mjd)
+        sed = self._get_sed(mjd=mjd)
         if sed is not None:
             sed = self._apply_component_extinction(sed)
         return sed

--- a/skycatalogs/objects/sncosmo_object.py
+++ b/skycatalogs/objects/sncosmo_object.py
@@ -14,9 +14,8 @@ class SncosmoObject(BaseObject):
         sn = SncosmoModel(params=params)
 
         if mjd < sn.mintime() or mjd > sn.maxtime():
-            return None, 0.0
-        # Already normalized so magnorm is zero
-        return sn.get_sed(mjd), 0.0
+            return None
+        return sn.get_sed(mjd)
 
     def get_gsobject_components(self, gsparams=None, rng=None):
         if gsparams is not None:
@@ -30,7 +29,7 @@ class SncosmoObject(BaseObject):
             txt = 'SncosmoObject._get_sed: no mjd specified for this call\n'
             txt += 'nor when generating object list'
             raise ValueError(txt)
-        sed, _ = self._get_sed(mjd=mjd)
+        sed = self._get_sed(mjd=mjd)
         if sed is not None:
             sed = self._apply_component_extinction(sed)
         return sed

--- a/skycatalogs/objects/sso_object.py
+++ b/skycatalogs/objects/sso_object.py
@@ -4,6 +4,7 @@ import numpy as np
 import galsim
 from .base_object import BaseObject, ObjectCollection
 from lsst.sphgeom import UnitVector3d, LonLat
+from ..utils import normalize_sed
 
 EXPOSURE_DEFAULT = 30.0         # seconds
 __all__ = ['SsoObject', 'SsoCollection', 'EXPOSURE_DEFAULT']
@@ -92,7 +93,7 @@ class SsoObject(BaseObject):
             raise ValueError(txt)
 
         sed, magnorm = self._get_sed(mjd=mjd)
-        sed = sed.withMagnitude(magnorm, self._bp500)
+        sed = normalize_sed(sed, magnorm)
 
         # no extinction
         return sed

--- a/skycatalogs/objects/sso_object.py
+++ b/skycatalogs/objects/sso_object.py
@@ -28,7 +28,7 @@ class SsoObject(BaseObject):
 
     def _get_sed(self, mjd=None):
         '''
-        returns a SED and magnorm
+        returns the SED
         mjd is required
         '''
         if SsoObject._solar_sed is None:
@@ -38,7 +38,8 @@ class SsoObject(BaseObject):
             # directly or are there other effects to be applied?
             # Have to find it by looking for entry for this id, this mjd
             # Do we look for specific entry or do we allow interpolation?
-        return SsoObject._solar_sed, self.get_native_attribute('trailed_source_mag')
+        magnorm = self.get_native_attribute('trailed_source_mag')
+        return normalize_sed(SsoObject._solar_sed, magnorm)
 
     def get_gsobject_components(self, gsparams=None, rng=None,
                                 streak=True):
@@ -92,8 +93,7 @@ class SsoObject(BaseObject):
             txt += 'nor when generating object list'
             raise ValueError(txt)
 
-        sed, magnorm = self._get_sed(mjd=mjd)
-        sed = normalize_sed(sed, magnorm)
+        sed = self._get_sed(mjd=mjd)
 
         # no extinction
         return sed

--- a/skycatalogs/objects/star_object.py
+++ b/skycatalogs/objects/star_object.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import galsim
 from .base_object import BaseObject
+from ..utils import normalize_sed
 
 __all__ = ['StarObject']
 
@@ -29,7 +30,7 @@ class StarObject(BaseObject):
     def get_observer_sed_component(self, component, mjd=None):
         sed, magnorm = self._get_sed(mjd=mjd)
 
-        sed = sed.withMagnitude(magnorm, self._bp500)
+        sed = normalize_sed(sed, magnorm)
 
         if sed is not None:
             sed = self._apply_component_extinction(sed)

--- a/skycatalogs/objects/star_object.py
+++ b/skycatalogs/objects/star_object.py
@@ -20,7 +20,7 @@ class StarObject(BaseObject):
         fpath = os.path.join(os.getenv('SIMS_SED_LIBRARY_DIR'),
                              self.get_native_attribute('sed_filepath'))
 
-        return self._get_sed_from_file(fpath), mag_norm
+        return normalize_sed(self._get_sed_from_file(fpath), mag_norm)
 
     def get_gsobject_components(self, gsparams=None, rng=None):
         if gsparams is not None:
@@ -28,9 +28,7 @@ class StarObject(BaseObject):
         return {'this_object': galsim.DeltaFunction(gsparams=gsparams)}
 
     def get_observer_sed_component(self, component, mjd=None):
-        sed, magnorm = self._get_sed(mjd=mjd)
-
-        sed = normalize_sed(sed, magnorm)
+        sed = self._get_sed(mjd=mjd)
 
         if sed is not None:
             sed = self._apply_component_extinction(sed)

--- a/tests/test_sed_tools.py
+++ b/tests/test_sed_tools.py
@@ -1,0 +1,44 @@
+import unittest
+import astropy.units as u
+import astropy.constants
+import numpy as np
+import galsim
+from skycatalogs.utils import normalize_sed
+
+
+class NormalizeSedTestCase(unittest.TestCase):
+    """TestCase class for normalizing SEDs with magnorm."""
+
+    def setUp(self):
+        """No set up needed."""
+        pass
+
+    def tearDown(self):
+        """Nothing to tear down."""
+        pass
+
+    def test_normalize_sed(self):
+        """Test the normalize_sed function"""
+        sed = galsim.SED(lambda wl: 1, "nm", "flambda", fast=False)
+        wl = 400 * u.nm
+
+        # Check that the ratio of differently normalized SEDs have the
+        # expected magnitude difference at the reference wavelength:
+        magnorm0 = 20.0
+        magnorm1 = 25.0
+        sed0 = normalize_sed(sed, magnorm0, wl=wl)
+        sed1 = normalize_sed(sed, magnorm1, wl=wl)
+
+        self.assertAlmostEqual(sed0(wl) / sed1(wl), 10 ** ((magnorm1 - magnorm0) / 2.5))
+
+        # Check the implied magnitude of the renormalized SED at the
+        # reference wavelength against the magnorm value.
+        hnu = (astropy.constants.h * astropy.constants.c / wl).to_value(u.erg)
+        fnu = sed0(wl) * hnu / (astropy.constants.c / wl**2).to_value(u.Hz / u.nm)
+        mag = -2.5 * np.log10(fnu) - 48.60
+
+        self.assertAlmostEqual(mag, magnorm0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a more reliable way to set the SED normalization using the magnorm value, and it also fixes the mismatch between flux calculations for stars when using galsim 2.4.8 vs 2.5.1+.

I also simplified the `BaseObject._get_sed` interface since passing back magnorm is no longer needed (and in most cases, that value was being ignored anyway).