### PR TITLE
two small fixes to gaia_object.py

### DIFF
--- a/skycatalogs/objects/gaia_object.py
+++ b/skycatalogs/objects/gaia_object.py
@@ -237,7 +237,10 @@ class GaiaCollection(ObjectCollection):
     @classmethod
     def set_config(cls, config):
         GaiaCollection._gaia_config = config
-        GaiaCollection._id_prefix = config['id_prefix']
+        if 'id_prefix' in config.keys():
+            GaiaCollection._id_prefix = config['id_prefix']
+        else:
+            GaiaCollection._id_prefix = '_gaia'
 
     @classmethod
     def get_config(cls):
@@ -245,13 +248,14 @@ class GaiaCollection(ObjectCollection):
 
     @ignore_erfa_warnings
     @staticmethod
-    def load_collection(region, skycatalog, mjd=None):
+    def load_collection(region, skycatalog, mjd=None, exposure=None):
         '''
         region      One of Disk, PolygonalRegion from skyCatalogs.utils.shapes.
                     Box is not currently supported
         skycatalog  An instance of the SkyCatalog class
         mjd         Time at which objects are to be assembled. Ignored for
                     Gaia stars
+        exposure    exposure length.  Ignored for Gaia stars
         '''
         if not skycatalog:
             raise ValueError('GaiaCollection.load_collection: skycatalog cannot be None')


### PR DESCRIPTION
Fix two things affecting gaia objects:
1. Interface for `load_collection` changed a while back to include a new optional argument, `exposure`, but `GaiaCollection.load_collection` was not updated at the time.  It's done in this PR
2. A while ago a config value `id_prefix` in the section about Gaia stars.  If it was omitted from the config and someone wanted to include Gaia stars in their search, skyCatalogs would crash.   The fix here is to use a default value if the key is omitted from the config.