### PR TITLE
Minimize LSST stack dependency

### DIFF
--- a/skycatalogs/__init__.py
+++ b/skycatalogs/__init__.py
@@ -1,5 +1,3 @@
 from ._version import __version__
 
 from .skyCatalogs import *
-from .main_catalog_creator import *
-from .flux_catalog_creator import *

--- a/skycatalogs/objects/__init__.py
+++ b/skycatalogs/objects/__init__.py
@@ -1,2 +1,1 @@
 from .base_object import *
-from .gaia_object import *

--- a/skycatalogs/skyCatalogs.py
+++ b/skycatalogs/skyCatalogs.py
@@ -10,7 +10,6 @@ from skycatalogs.objects.base_object import _load_lsst_bandpasses
 from skycatalogs.objects.base_object import _load_roman_bandpasses
 from skycatalogs.utils.catalog_utils import CatalogContext
 from skycatalogs.objects.base_object import ObjectList, ObjectCollection
-from skycatalogs.objects.gaia_object import GaiaObject, GaiaCollection
 from skycatalogs.objects.sso_object import SsoObject, SsoCollection
 from skycatalogs.objects.sso_object import EXPOSURE_DEFAULT
 from skycatalogs.readers import ParquetReader
@@ -262,6 +261,7 @@ class SkyCatalog(object):
 
         # register object types which are in the config
         if 'gaia_star' in config['object_types']:
+            from skycatalogs.objects.gaia_object import GaiaObject, GaiaCollection
             self.cat_cxt.register_source_type('gaia_star',
                                               object_class=GaiaObject,
                                               collection_class=GaiaCollection,

--- a/skycatalogs/utils/shapes.py
+++ b/skycatalogs/utils/shapes.py
@@ -3,8 +3,7 @@ import numpy as np
 import healpy
 from astropy import units as u
 import healpy
-import lsst.geom
-from lsst.sphgeom import ConvexPolygon, UnitVector3d, LonLat, Circle
+from lsst.sphgeom import Angle, ConvexPolygon, UnitVector3d, LonLat, Circle
 
 __all__ = ['Box', 'Disk', 'PolygonalRegion']
 
@@ -125,11 +124,9 @@ class Disk(Region):
 
     def sphgeom_region(self):
         """Enclosing region expressed as lsst.sphgeom.Circle."""
-        ra = lsst.geom.Angle(self.ra, lsst.geom.degrees)
-        dec = lsst.geom.Angle(self.dec, lsst.geom.degrees)
-        center = lsst.geom.SpherePoint(ra, dec)
-        radius = lsst.geom.Angle(self.radius.to_value("degree"))
-        return Circle(center.getVector(), radius)
+        center = LonLat.fromDegrees(ra, dec)
+        radius = Angle(self.radius.to_value("radian"))
+        return Circle(UnitVector3d(center), radius)
 
 
 class PolygonalRegion(Region):


### PR DESCRIPTION
Closes #113 (ideally)

I've finally taken a stab at implementing the changes I mentioned in #113 . The one instance where `sphgeom` would do instead of `geom`, I've switched to using it. I've also removed top-level imports so that modules that are not needed aren't imported ahead of time. These are technically breaking changes but since we just bumped to a major version, I am hoping we can sneak these changes in soon enough and consider it part of `v2`.

I've confirmed that I am able to use `skyCatalogs` in the Roman simulation context without the whole stack but just with `lsst-sphgeom` installed from `pip`. One thing that we should discuss is how to split the tests so we can clearly document which ones need the whole stack and which ones don't. In particular, it'd prevent any future proliferation of the full stack dependence when it is not necessary.